### PR TITLE
Fix font loading and missing icons

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -31,6 +31,11 @@
 
   <title>film_management</title>
   <link rel="manifest" href="manifest.json">
+
+  <!-- Material Icons for Flutter web -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 <body>
   <script src="flutter_bootstrap.js" async></script>


### PR DESCRIPTION
Add Material Icons stylesheet links to `web/index.html` to fix missing icons on Flutter Web.

Flutter Web requires an explicit stylesheet link for Material Icons in `index.html` to render them correctly; otherwise, icons appear as empty boxes.

---
<a href="https://cursor.com/background-agent?bcId=bc-aa28c061-3435-4a3e-bf13-aa9fabf06831">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-aa28c061-3435-4a3e-bf13-aa9fabf06831">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

